### PR TITLE
docs: update docs on log retention period.

### DIFF
--- a/docs/docs/cli-reference/service-logs.md
+++ b/docs/docs/cli-reference/service-logs.md
@@ -17,7 +17,7 @@ where `$THE_ENCLAVE_IDENTIFIER` and the `$THE_SERVICE_IDENTIFIER` are [resource 
 By default, logs printed in the terminal from this command are truncated at the most recent 200 log lines. For a stream of logs, we recommend the `-f` flag. For all the logs use the `-a` flag and for a snapshot of the logs at a given point in time (e.g. after a change), we recommend the [`kurtosis dump`](./dump.md).
 
 :::note Log Retention
-Kurtosis will keep logs for up to 4 weeks before removing them to prevent logs from taking up to much storage. If you'd like to remove logs before the retention period, `kurtosis enclave rm` will remove any logs associated for service in the enclave and `kurtosis clean` will remove logs for all services in stopped enclaves.
+Kurtosis will keep logs for up to 1 week before removing them to prevent logs from taking up to much storage. If you'd like to remove logs before the retention period, `kurtosis enclave rm` will remove any logs associated for service in the enclave and `kurtosis clean` will remove logs for all services in stopped enclaves.
 :::
 
 The following optional arguments can be used:


### PR DESCRIPTION
## Description

Logs retention period was updated to 1 week in #2403. This PR updates the documentation. 

## REMINDER: Tag Reviewers, so they get notified to review

@tedim52

## Is this change user facing?
YES
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable)

https://github.com/kurtosis-tech/kurtosis/blob/7562dcb4859524bfe2c80a4328945577736ed9a4/engine/server/engine/centralized_logs/client_implementations/persistent_volume/volume_consts/consts.go#L21
